### PR TITLE
Fixes train (de-)serialization for Factorio 0.18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Clusterio plugin for teleporting trains between servers
 
 ## Installation ##
 1. install the [clusterio server](https://github.com/Danielv123/factorioClusterio)
-2. install this project under the sharedPlugins folder
+2. install this project under the sharedPlugins folder in a folder named trainTeleports
 

--- a/lua/train_tracking.lua
+++ b/lua/train_tracking.lua
@@ -74,8 +74,8 @@ local function serialize_inventory(inventory)
     local filters
 
     local bar = nil
-    if inventory.hasbar() then
-        bar = inventory.getbar()
+    if inventory.supports_bar() then
+        bar = inventory.get_bar()
     end
 
     if inventory.supports_filters() then
@@ -259,8 +259,8 @@ local function deserialize_inventory(inventory, data)
     = data.item_names, data.item_counts, data.item_durabilities,
     data.item_ammos, data.item_exports, data.item_labels, data.item_grids
 
-    if inventory.hasbar() then
-        inventory.setbar(data.bar)
+    if inventory.supports_bar() then
+        inventory.set_bar(data.bar)
     end
 
     for idx, name in pairs(item_names) do


### PR DESCRIPTION
Train (de-)serialization broke in Factorio 0.18.x as methods `hasbar`, `getbar` and `setbar` have been renamed to `supports_bar`, `get_bar` and `set_bar` respectively.

Fix suggested by Hornwitser#6431 on Discord.

Also added correct folder name to README as the index.js requires the plugin to be installed specifically in `sharedPlugins/trainTeleports/`, otherwise it will not load.